### PR TITLE
update alpine to latest stable tag

### DIFF
--- a/tmp/build/Dockerfile
+++ b/tmp/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 RUN adduser -D puffin-operator
 USER puffin-operator


### PR DESCRIPTION
hey kris,

thanks again, great talk :)

as of earlier latest stable tag is 3.7.
should be no problem, since there are no dependencies on the alpine image.

all the best,

Benjamin